### PR TITLE
Allow multiple label sets per metric

### DIFF
--- a/spec/prometheus_spec.cr
+++ b/spec/prometheus_spec.cr
@@ -24,7 +24,7 @@ describe Prometheus do
     it "returns the collection of all values for all label sets" do
       counter = Prometheus.counter("test_counter", "A test counter", labels: {"foo" => "bar"})
       counter.inc 1
-      counter.inc 2, labels: Prometheus::LabelSet.new({"baz" => "quux"})
+      counter.inc 2, labels: {"baz" => "quux"}
 
       counter.collect.should eq [
         Prometheus::Sample.new("test_counter", Prometheus::LabelSet.new({"foo" => "bar"}), 1.0),

--- a/spec/prometheus_spec.cr
+++ b/spec/prometheus_spec.cr
@@ -20,6 +20,17 @@ describe Prometheus do
         counter.inc(-1)
       end
     end
+
+    it "returns the collection of all values for all label sets" do
+      counter = Prometheus.counter("test_counter", "A test counter", labels: {"foo" => "bar"})
+      counter.inc 1
+      counter.inc 2, labels: Prometheus::LabelSet.new({"baz" => "quux"})
+
+      counter.collect.should eq [
+        Prometheus::Sample.new("test_counter", Prometheus::LabelSet.new({"foo" => "bar"}), 1.0),
+        Prometheus::Sample.new("test_counter", Prometheus::LabelSet.new({"foo" => "bar", "baz" => "quux"}), 2.0),
+      ]
+    end
   end
 
   describe "Gauge" do
@@ -36,42 +47,89 @@ describe Prometheus do
       gauge.dec(1)
       gauge.value.should eq(1.0)
     end
+
+    it "returns the collection of all values for all label sets" do
+      gauge = Prometheus.gauge("test_gauge", "A test gauge", labels: {"foo" => "bar"})
+      gauge.inc 1
+      gauge.inc 2, labels: Prometheus::LabelSet.new({"baz" => "quux"})
+
+      gauge.collect.should eq [
+        Prometheus::Sample.new("test_gauge", Prometheus::LabelSet.new({"foo" => "bar"}), 1.0),
+        Prometheus::Sample.new("test_gauge", Prometheus::LabelSet.new({"foo" => "bar", "baz" => "quux"}), 2.0),
+      ]
+    end
   end
 
   describe "Histogram" do
     it "observes values in buckets" do
       buckets = [1.0, 2.0, 5.0]
       histogram = Prometheus.histogram("test_histogram", "A test histogram", buckets)
-      
+
       histogram.observe(1.5)
       histogram.observe(2.5)
       histogram.observe(4.5)
 
       samples = histogram.collect
-      
+
       # Check bucket counts
       samples.find { |s| s.name == "test_histogram_bucket" && s.labels.labels["le"] == "1.0" }.try(&.value).should eq(0)
       samples.find { |s| s.name == "test_histogram_bucket" && s.labels.labels["le"] == "2.0" }.try(&.value).should eq(1)
       samples.find { |s| s.name == "test_histogram_bucket" && s.labels.labels["le"] == "5.0" }.try(&.value).should eq(3)
-      
+
       # Check sum and count
       samples.find { |s| s.name == "test_histogram_sum" }.try(&.value).should eq(8.5)
       samples.find { |s| s.name == "test_histogram_count" }.try(&.value).should eq(3)
+    end
+
+    it "returns the collection of all values for all label sets" do
+      histogram = Prometheus.histogram "test_histogram", "A test histogram",
+        buckets: [1.0, 2.0],
+        labels: {"foo" => "bar"}
+
+      histogram.observe 1
+      histogram.observe 2.5, labels: Prometheus::LabelSet.new({"baz" => "quux"})
+      histogram.observe 2, labels: Prometheus::LabelSet.new({"baz" => "quux"})
+
+      metrics = histogram.collect
+
+      metrics.should contain Prometheus::Sample.new("test_histogram_sum", {"foo" => "bar"}, 1.0)
+      metrics.should contain Prometheus::Sample.new("test_histogram_count", {"foo" => "bar"}, 1.0)
+      metrics.should contain Prometheus::Sample.new("test_histogram_bucket", {"foo" => "bar", "le" => "1.0"}, 1.0)
+      metrics.should contain Prometheus::Sample.new("test_histogram_bucket", {"foo" => "bar", "le" => "2.0"}, 1.0)
+      metrics.should contain Prometheus::Sample.new("test_histogram_sum", {"foo" => "bar", "baz" => "quux"}, 4.5)
+      metrics.should contain Prometheus::Sample.new("test_histogram_count", {"foo" => "bar"}, 1.0)
+      metrics.should contain Prometheus::Sample.new("test_histogram_bucket", {"foo" => "bar", "baz" => "quux", "le" => "1.0"}, 0.0)
+      metrics.should contain Prometheus::Sample.new("test_histogram_bucket", {"foo" => "bar", "baz" => "quux", "le" => "2.0"}, 1.0)
     end
   end
 
   describe "Summary" do
     it "tracks count and sum" do
       summary = Prometheus.summary("test_summary", "A test summary")
-      
+
       summary.observe(2.0)
       summary.observe(4.0)
       summary.observe(6.0)
 
       samples = summary.collect
-      
+
       samples.find { |s| s.name == "test_summary_sum" }.try(&.value).should eq(12.0)
       samples.find { |s| s.name == "test_summary_count" }.try(&.value).should eq(3)
+    end
+
+    it "returns the collection of all values for all label sets" do
+      summary = Prometheus.summary("test_summary", "A test summary")
+      summary.observe 1
+      summary.observe 2
+      summary.observe 3, Prometheus::LabelSet.new({"foo" => "bar"})
+      summary.observe 4, Prometheus::LabelSet.new({"foo" => "bar"})
+
+      empty = Prometheus::LabelSet.new
+      metrics = summary.collect
+      metrics.should contain Prometheus::Sample.new("test_summary_sum", empty, 3)
+      metrics.should contain Prometheus::Sample.new("test_summary_count", empty, 2)
+      metrics.should contain Prometheus::Sample.new("test_summary_sum", {"foo" => "bar"}, 7)
+      metrics.should contain Prometheus::Sample.new("test_summary_count", {"foo" => "bar"}, 2)
     end
   end
 

--- a/src/metrics.cr
+++ b/src/metrics.cr
@@ -28,6 +28,11 @@ module Prometheus
       store.inc value.to_f64, label_set_for(labels)
     end
 
+    def inc!(value : Number = 1, labels : LabelSet? = nil)
+      raise ArgumentError.new("Counter increment must be positive") if value < 0
+      store.inc! value.to_f64, label_set_for(labels)
+    end
+
     def value(labels : LabelSet? = nil) : Float64
       store.get label_set_for(labels)
     end
@@ -126,15 +131,15 @@ module Prometheus
 
     def observe(value : Number, labels : Labels? = nil)
       @mutex.synchronize do
-        @count.inc 1, labels
-        @sum.inc value, labels
+        @count.inc! 1, labels
+        @sum.inc! value, labels
         @buckets.each do |upper_bound, bucket|
           if value <= upper_bound
             inc = 1
           else
             inc = 0
           end
-          bucket.inc inc, labels
+          bucket.inc! inc, labels
         end
       end
     end
@@ -188,8 +193,8 @@ module Prometheus
 
     def observe(value : Number, labels : LabelSet? = nil)
       @mutex.synchronize do
-        @count.inc 1, labels
-        @sum.inc value, labels
+        @count.inc! 1, labels
+        @sum.inc! value, labels
       end
     end
 

--- a/src/metrics.cr
+++ b/src/metrics.cr
@@ -11,34 +11,25 @@ module Prometheus
   # * Number of errors
   #
   # Example:
-  # ```crystal
+  # ```
   # counter = Counter.new("http_requests_total", "Total HTTP requests")
-  # counter.inc      # Increment by 1
-  # counter.inc(5)   # Increment by 5
+  # counter.inc    # Increment by 1
+  # counter.inc(5) # Increment by 5
   # ```
   #
   # NOTE: Counter values cannot decrease. Use a Gauge for values that can go up and down.
   class Counter < Metric
-    @value : Float64 = 0.0
-    @mutex = Mutex.new
-
     def type : String
       "counter"
     end
 
-    def inc(value : Number = 1)
+    def inc(value : Number = 1, labels : LabelSet? = nil)
       raise ArgumentError.new("Counter increment must be positive") if value < 0
-      @mutex.synchronize do
-        @value += value.to_f64
-      end
+      store.inc value.to_f64, label_set_for(labels)
     end
 
-    def value : Float64
-      @mutex.synchronize { @value }
-    end
-
-    def collect : Array(Sample)
-      [Sample.new(@name, @labels, value)]
+    def value(labels : LabelSet? = nil) : Float64
+      store.get label_set_for(labels)
     end
   end
 
@@ -50,44 +41,31 @@ module Prometheus
   # * Number of active connections
   #
   # Example:
-  # ```crystal
+  # ```
   # gauge = Gauge.new("cpu_usage", "CPU usage percentage")
-  # gauge.set(45.2)  # Set to specific value
-  # gauge.inc(5)     # Increase by 5
-  # gauge.dec(3)     # Decrease by 3
+  # gauge.set(45.2) # Set to specific value
+  # gauge.inc(5)    # Increase by 5
+  # gauge.dec(3)    # Decrease by 3
   # ```
   class Gauge < Metric
-    @value : Float64 = 0.0
-    @mutex = Mutex.new
-
     def type : String
       "gauge"
     end
 
-    def set(value : Number)
-      @mutex.synchronize do
-        @value = value.to_f64
-      end
+    def set(value : Number, labels : Labels? = nil)
+      store.set value, label_set_for(labels)
     end
 
-    def inc(value : Number = 1)
-      @mutex.synchronize do
-        @value += value.to_f64
-      end
+    def inc(value : Number = 1, labels : Labels? = nil)
+      store.inc value, label_set_for(labels)
     end
 
-    def dec(value : Number = 1)
-      @mutex.synchronize do
-        @value -= value.to_f64
-      end
+    def dec(value : Number = 1, labels : Labels? = nil)
+      store.dec value, label_set_for(labels)
     end
 
-    def value : Float64
-      @mutex.synchronize { @value }
-    end
-
-    def collect : Array(Sample)
-      [Sample.new(@name, @labels, value)]
+    def value(labels : Labels? = nil) : Float64
+      store.get label_set_for(labels)
     end
   end
 
@@ -100,7 +78,7 @@ module Prometheus
   # * Queue length variations
   #
   # Example:
-  # ```crystal
+  # ```
   # # Create with custom buckets
   # histogram = Histogram.new(
   #   "response_time",
@@ -117,52 +95,59 @@ module Prometheus
   # * Total sum of all observed values
   # * Count of all observed values
   class Histogram < Metric
+    @buckets : Array({Float64, Counter})
     @mutex = Mutex.new
-    @sum : Float64 = 0.0
-    @count : UInt64 = 0
-    @buckets : Hash(Float64, UInt64)
+    @count : Counter
+    @sum : Counter
 
     def initialize(name : String, help : String, buckets : Array(Float64), labels = LabelSet.new)
       super(name, help, labels)
-      @buckets = Hash(Float64, UInt64).new(0_u64)
-      buckets.sort.each { |upper_bound| @buckets[upper_bound] = 0_u64 }
+      @count = Counter.new("#{name}_count", help, labels: labels)
+      @sum = Counter.new("#{name}_sum", help, labels: labels)
+      @buckets = buckets.sort.map do |bucket|
+        counter = Counter.new("#{name}_bucket", help, labels: labels.merge({
+          "le" => bucket.to_s,
+        }))
+        counter.store.set 0f64, counter.labels
+
+        {bucket, counter}
+      end
+      infinity = Counter.new("#{name}_bucket", help, labels: labels.merge({"le" => "+Inf"}))
+      @buckets << {
+        Float64::INFINITY,
+        infinity,
+      }
+      infinity.store.set 0f64, infinity.labels
     end
 
     def type : String
       "histogram"
     end
 
-    def observe(value : Number)
-      value_f64 = value.to_f64
+    def observe(value : Number, labels : Labels? = nil)
       @mutex.synchronize do
-        @sum += value_f64
-        @count += 1
-        # Update all buckets that have an upper bound greater than or equal to the value
-        @buckets.each do |upper_bound, _|
-          if value_f64 <= upper_bound
-            @buckets[upper_bound] += 1
+        @count.inc 1, labels
+        @sum.inc value, labels
+        @buckets.each do |upper_bound, bucket|
+          if value <= upper_bound
+            inc = 1
+          else
+            inc = 0
           end
+          bucket.inc inc, labels
         end
       end
     end
 
     def collect : Array(Sample)
       @mutex.synchronize do
-        samples = [] of Sample
-        
-        # Add bucket samples
-        @buckets.each do |upper_bound, count|
-          bucket_label = @labels.merge(LabelSet.new({"le" => upper_bound.to_s}))
-          samples << Sample.new("#{@name}_bucket", bucket_label, count.to_f64)
+        samples = Array(Sample).new(@buckets.size + 2)
+          .concat(@count.collect)
+          .concat(@sum.collect)
+
+        @buckets.each do |upper_bound, bucket|
+          samples.concat bucket.collect
         end
-
-        # Add +Inf bucket
-        inf_label = @labels.merge(LabelSet.new({"le" => "+Inf"}))
-        samples << Sample.new("#{@name}_bucket", inf_label, @count.to_f64)
-
-        # Add sum and count metrics
-        samples << Sample.new("#{@name}_sum", @labels, @sum)
-        samples << Sample.new("#{@name}_count", @labels, @count.to_f64)
 
         samples
       end
@@ -178,7 +163,7 @@ module Prometheus
   # * Response sizes
   #
   # Example:
-  # ```crystal
+  # ```
   # summary = Summary.new("request_size", "Request size in bytes")
   # summary.observe(1024)
   # ```
@@ -188,30 +173,31 @@ module Prometheus
   # * Sum of all observed values
   class Summary < Metric
     @mutex = Mutex.new
-    @count : UInt64 = 0
-    @sum : Float64 = 0.0
+    @count : Counter
+    @sum : Counter
 
     def initialize(name : String, help : String, labels = LabelSet.new)
       super(name, help, labels)
+      @count = Counter.new("#{name}_count", help, labels)
+      @sum = Counter.new("#{name}_sum", help, labels)
     end
 
     def type : String
       "summary"
     end
 
-    def observe(value : Number)
+    def observe(value : Number, labels : LabelSet? = nil)
       @mutex.synchronize do
-        @count += 1
-        @sum += value.to_f64
+        @count.inc 1, labels
+        @sum.inc value, labels
       end
     end
 
     def collect : Array(Sample)
       @mutex.synchronize do
-        [
-          Sample.new("#{@name}_sum", @labels, @sum),
-          Sample.new("#{@name}_count", @labels, @count.to_f64)
-        ]
+        Array(Sample).new(labels.size * 2)
+          .concat(@count.collect)
+          .concat(@sum.collect)
       end
     end
   end

--- a/src/prometheus.cr
+++ b/src/prometheus.cr
@@ -33,7 +33,6 @@ require "./registry"
 module Prometheus
   VERSION = "0.1.0"
 
-
   # Creates and registers a new Counter metric.
   #
   # A Counter is a cumulative metric that represents a single monotonically increasing counter

--- a/src/prometheus.cr
+++ b/src/prometheus.cr
@@ -10,7 +10,7 @@ require "./registry"
 #
 # ## Basic Usage
 #
-# ```crystal
+# ```
 # # Create metrics
 # counter = Prometheus.counter("http_requests_total", "Total HTTP requests")
 # gauge = Prometheus.gauge("cpu_usage", "CPU usage percentage")
@@ -38,10 +38,10 @@ module Prometheus
   # A Counter is a cumulative metric that represents a single monotonically increasing counter
   # whose value can only increase or be reset to zero.
   #
-  # ```crystal
+  # ```
   # counter = Prometheus.counter("http_requests_total", "Total HTTP requests")
-  # counter.inc      # Increment by 1
-  # counter.inc(5)   # Increment by 5
+  # counter.inc    # Increment by 1
+  # counter.inc(5) # Increment by 5
   # ```
   #
   # Parameters:
@@ -60,6 +60,10 @@ module Prometheus
     Registry.default.clear
   end
 
+  def self.collect(io : IO) : Nil
+    Registry.default.collect io
+  end
+
   def self.collect : String
     Registry.default.collect
   end
@@ -68,11 +72,11 @@ module Prometheus
   #
   # A Gauge is a metric that represents a single numerical value that can arbitrarily go up and down.
   #
-  # ```crystal
+  # ```
   # gauge = Prometheus.gauge("cpu_usage", "CPU usage percentage")
-  # gauge.set(45.2)  # Set to 45.2
-  # gauge.inc(5)     # Increase by 5
-  # gauge.dec(3)     # Decrease by 3
+  # gauge.set(45.2) # Set to 45.2
+  # gauge.inc(5)    # Increase by 5
+  # gauge.dec(3)    # Decrease by 3
   # ```
   #
   # Parameters:
@@ -96,7 +100,7 @@ module Prometheus
   # A Histogram samples observations (usually things like request durations or response sizes)
   # and counts them in configurable buckets.
   #
-  # ```crystal
+  # ```
   # histogram = Prometheus.histogram(
   #   "response_time",
   #   "Response time in seconds",
@@ -121,7 +125,7 @@ module Prometheus
   # A Summary captures individual observations from an event or sample stream
   # and summarizes them in a traditional way, with count and sum.
   #
-  # ```crystal
+  # ```
   # summary = Prometheus.summary("request_size", "Request size in bytes")
   # summary.observe(1024)
   # ```

--- a/src/registry.cr
+++ b/src/registry.cr
@@ -12,7 +12,7 @@ module Prometheus
   # A default registry is provided via `Prometheus.register`, but you can also create
   # your own registries if needed:
   #
-  # ```crystal
+  # ```
   # # Using default registry
   # Prometheus.register(metric)
   # output = Prometheus.collect
@@ -34,7 +34,7 @@ module Prometheus
     # Each metric name must be unique within a registry. Attempting to register
     # a metric with a name that's already in use will raise an ArgumentError.
     #
-    # ```crystal
+    # ```
     # counter = Counter.new("http_requests_total", "Total HTTP requests")
     # registry.register(counter)
     # ```
@@ -52,7 +52,7 @@ module Prometheus
 
     # Unregisters a metric by name.
     #
-    # ```crystal
+    # ```
     # registry.unregister("http_requests_total")
     # ```
     def unregister(name : String)
@@ -63,7 +63,7 @@ module Prometheus
 
     # Removes all metrics from the registry.
     #
-    # ```crystal
+    # ```
     # registry.clear
     # ```
     def clear
@@ -81,26 +81,29 @@ module Prometheus
     # http_requests_total{method="GET"} 42
     # ```
     #
-    # ```crystal
+    # ```
     # output = registry.collect
     # puts output
     # ```
     def collect : String
-      output = String.build do |io|
-        @mutex.synchronize do
-          @metrics.each do |_, metric|
-            # Write help comment
-            io << "# HELP " << metric.name << " " << metric.help << "\n"
-            # Write type comment
-            io << "# TYPE " << metric.name << " " << metric.type << "\n"
-            # Write samples
-            metric.collect.each do |sample|
-              io << sample << "\n"
-            end
+      String.build do |io|
+        collect io
+      end
+    end
+
+    def collect(io : IO) : Nil
+      @mutex.synchronize do
+        @metrics.each do |_, metric|
+          # Write help comment
+          io << "# HELP " << metric.name << " " << metric.help << "\n"
+          # Write type comment
+          io << "# TYPE " << metric.name << " " << metric.type << "\n"
+          # Write samples
+          metric.collect.each do |sample|
+            io << sample << "\n"
           end
         end
       end
-      output
     end
 
     # Default global registry instance

--- a/src/types.cr
+++ b/src/types.cr
@@ -195,7 +195,11 @@ module Prometheus
     end
 
     def inc(value : Float64, labels : LabelSet) : Nil
-      sync { @data[labels] += value }
+      sync { inc! value, labels }
+    end
+
+    protected def inc!(value : Float64, labels : LabelSet) : Nil
+      @data[labels] += value
     end
 
     def dec(value : Float64, labels : LabelSet) : Nil


### PR DESCRIPTION
Thanks for writing this shard. It's really well done!

The only thing that I'm stumbling over is that I can't have multiple label sets for the same metric. For example, it doesn't seem like I can emit the metrics `http_request_count{status_class="2xx"}` and `http_request_count{status_class="5xx"}` using the same registry. 

This PR adds support for that by giving each metric a data store instead of a single scalar value. Method calls on the metric delegate to the data store, which tracks all of the values for all of the label sets used.

There are some things to improve in this PR, so it's not done yet. For example, I implemented histograms and summaries in terms of counters (one for count, one for sum, and one for each bucket) because I didn't want to have to duplicate all of that logic, however that means it N+1 mutex calls (one for the histogram and one for each counter … for _each label set_), which has performance implications. I'm considering adding a `protected def Counter#inc!` method that bypasses the mutex to mitigate that.

I wrote a quick benchmark to see what the performance implications would be. As expected, it had the largest impact on histograms, which were already the slowest and are known to be heavy in Prometheus simply due to the quantity of time series they require.

<details><summary>Benchmark code</summary>

```crystal
require "benchmark"
require "../src/prometheus"

Benchmark.ips do |x|
  counter = Prometheus.counter("http_requests_total", "Total HTTP Requests")
  gauge = Prometheus.gauge "cpu_usage", "CPU usage percentage"
  histogram = Prometheus.histogram "http_response_time", "HTTP response times in seconds",
    buckets: [0.01, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 2, 3, 5, 8, 13, 21, 30] of Float64
  summary = Prometheus.summary "http_response_errors", "HTTP Response Errors"

  x.report "counter" { counter.inc }
  x.report "gauge" { gauge.set 42 }
  x.report "histogram" { histogram.observe 0.25 }
  x.report "summary" { summary.observe 1 }
end
```

</details>

### Before

```
➜  crystal-prometheus-client git:(main) crr benchmark/metrics.cr
  counter 135.30M (  7.39ns) (± 5.64%)  0.0B/op   1.05× slower
    gauge 141.67M (  7.06ns) (± 3.89%)  0.0B/op        fastest
histogram   8.08M (123.75ns) (± 6.17%)  0.0B/op  17.53× slower
  summary 140.29M (  7.13ns) (± 3.20%)  0.0B/op   1.01× slower
```

### After

```
➜  crystal-prometheus-client git:(allow-multiple-labelsets-per-metric) crr benchmark/metrics.cr
  counter  85.96M ( 11.63ns) (± 2.59%)  0.0B/op   1.19× slower
    gauge 102.30M (  9.77ns) (± 3.82%)  0.0B/op        fastest
histogram   3.16M (316.75ns) (± 0.41%)  0.0B/op  32.40× slower
  summary  33.54M ( 29.81ns) (± 2.55%)  0.0B/op   3.05× slower
```

I don't think much can be done to improve the `Counter` and `Gauge` types with this PR. Adding 2ns of overhead per hash dereference (there's more of a difference for `Counter` than `Gauge` because it does a read _and_ a write via the data store hash whereas `Gauge` just does a write) is unavoidable. Removing the nested/repeated mutex usage should improve the histogram and summary performance dramatically, though. In other benchmarks I've run, I've found that each mutex lock is around 10ns. I added an unreasonable number of buckets to the histogram (the old rule of thumb for Prometheus was a cardinality of 10-12 and this histogram has 22 without any labels) as a pathological case to see what the performance hit would be there.