### PR TITLE
Optimize allocations used during `Registry#collect(io)`

### DIFF
--- a/spec/prometheus_spec.cr
+++ b/spec/prometheus_spec.cr
@@ -144,6 +144,19 @@ describe Prometheus do
       output.should contain("test_counter 5")
     end
 
+    it "collects metrics via an IO" do
+      buffer = IO::Memory.new
+      counter = Prometheus.counter("test_counter", "A test counter")
+      counter.inc 5
+
+      Prometheus.collect buffer
+      output = buffer.to_s
+
+      output.should contain("# HELP test_counter A test counter\n")
+      output.should contain("# TYPE test_counter counter\n")
+      output.should contain("test_counter 5")
+    end
+
     it "handles labels correctly" do
       labels = Prometheus::LabelSet.new({"handler" => "test"})
       counter = Prometheus.counter("http_requests_total", "Total HTTP requests", labels)

--- a/src/metrics.cr
+++ b/src/metrics.cr
@@ -147,6 +147,19 @@ module Prometheus
       end
     end
 
+    def collect(io : IO) : Nil
+      @mutex.synchronize do
+        @count.collect io
+        @sum.collect io
+        @buckets.each do |upper_bound, bucket|
+          @label_sets.each do |labels|
+            bucket.get! labels
+          end
+          bucket.collect io
+        end
+      end
+    end
+
     def collect : Array(Sample)
       @mutex.synchronize do
         samples = Array(Sample).new(@buckets.size + 2)

--- a/src/registry.cr
+++ b/src/registry.cr
@@ -93,15 +93,13 @@ module Prometheus
 
     def collect(io : IO) : Nil
       @mutex.synchronize do
-        @metrics.each do |_, metric|
+        @metrics.each_value do |metric|
           # Write help comment
           io << "# HELP " << metric.name << " " << metric.help << "\n"
           # Write type comment
           io << "# TYPE " << metric.name << " " << metric.type << "\n"
           # Write samples
-          metric.collect.each do |sample|
-            io << sample << "\n"
-          end
+          metric.collect io
         end
       end
     end


### PR DESCRIPTION
In #1 I accidentally committed part of an experiment that I meant to put here, which was the ability to pass an `IO` object to `collect`. So instead of adding it here, I'm optimizing what I accidentally committed before.

On a benchmark of a single histogram (many labels plus 2 counters), this PR is about 38% faster and incurs about 4.5x fewer bytes allocated on the heap.

<details><summary>Benchmark code</summary>

```crystal
require "benchmark"

require "../src/prometheus"

# 1MB buffer
buffer = IO::Memory.new(1 << 20)

http_requests = Prometheus.histogram("http_request_duration", "HTTP Request duration", buckets: [
  5.milliseconds,
  10.milliseconds,
  25.milliseconds,
  50.milliseconds,
  100.milliseconds,
  250.milliseconds,
  500.milliseconds,
  1.second,
  2.5.seconds,
  5.seconds,
  10.seconds,
].map(&.total_seconds))
1_000.times do |i|
  http_requests.observe rand(0.05...5.0), {
    "method"   => "GET",
    "endpoint" => "/api",
  }
end
Prometheus.collect STDOUT

Benchmark.ips do |x|
  x.report "collect" { Prometheus.collect buffer.rewind }
end
```

</details>

Before: `collect 310.73k (  3.22µs) (± 0.77%)  7.32kB/op  fastest`
After : `collect 429.68k (  2.33µs) (± 0.97%)  1.62kB/op  fastest`

When I increased the cardinality of the histograms (5 `method`s and 9 `endpoint`s, each permutation having 11 buckets — histograms are great for stress-testing cardinality) to have more metric lines to output, the difference was a bit less pronounced in terms of the multiplier (24.5% less time, 4.4x less heap), but still significant:

Before: `collect   8.38k (119.29µs) (± 0.66%)  249kB/op  fastest`
After : `collect  10.43k ( 95.85µs) (± 1.22%)  56.6kB/op  fastest`

I'm honestly surprised by the smallish difference in time, but the heap usage can get pretty big if you have a high metric cardinality. This PR helps it get less big.

Notable things:
- I converted some classes (like `Sample`) to `struct`s when they're short-lived and don't accrue state
- Added a `LabelCache` that avoids creating a new `LabelSet` for every permutation of the metric's labels combined with the individual sample's labels every time `collect` is called
- The main implementation detail is that, rather than transforming data structures, this PR just writes the metrics to the `IO` object
- I'd like to believe there's a way to get this close to 0 bytes allocated each time (after the labels are cached), but I haven't figured it out yet. There must be some allocations I haven't noticed yet.
- One advantage of accidentally committing that one change in #1 is that the benchmark code gets to stay the same because the API change is already there 😄